### PR TITLE
fix: version 3.13 replaces version 3.11

### DIFF
--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -58,7 +58,7 @@ func TestRunFSCloudExample(t *testing.T) {
 			"access_tags":                permanentResources["accessTags"],
 			"existing_kms_instance_guid": permanentResources["hpcs_south"],
 			"kms_key_crn":                permanentResources["hpcs_south_root_key_crn"],
-			"rabbitmq_version":           "3.12", // Always lock this test into the latest supported RabbitMQ version
+			"rabbitmq_version":           "3.13", // Always lock this test into the latest supported RabbitMQ version
 		},
 		CloudInfoService: sharedInfoSvc,
 	})
@@ -87,7 +87,7 @@ func TestRunCompleteUpgradeExample(t *testing.T) {
 		BestRegionYAMLPath: regionSelectionPath,
 		ResourceGroup:      resourceGroup,
 		TerraformVars: map[string]interface{}{
-			"rabbitmq_version": "3.11", // Always lock to the lowest supported RabbitMQ version
+			"rabbitmq_version": "3.12", // Always lock to the lowest supported RabbitMQ version
 			"users": []map[string]interface{}{
 				{
 					"name":     "testuser",

--- a/variables.tf
+++ b/variables.tf
@@ -20,10 +20,10 @@ variable "rabbitmq_version" {
   validation {
     condition = anytrue([
       var.rabbitmq_version == null,
-      var.rabbitmq_version == "3.11",
+      var.rabbitmq_version == "3.13",
       var.rabbitmq_version == "3.12"
     ])
-    error_message = "Version must be 3.11 or 3.12. If no value passed, the current ICD preferred version is used."
+    error_message = "Version must be 3.12 or 3.13. If no value passed, the current ICD preferred version is used."
   }
 }
 


### PR DESCRIPTION
### Description

```hcl
Database Type:  rabbitmq
Version   Status   Preferred
3.13      stable   true
3.12      stable   false
```

3.11 has been removed and replaced with 3.13. Updates to the validation and tests to retain min/max version constraints.

https://cloud.ibm.com/docs/cloud-databases?topic=cloud-databases-versioning-policy shows that 3.12 is next to EOL. No mention of 3.11.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

End of life for IBM Cloud Databases RabbitMQ version 3.11.
Added 3.13 (which is the preferred version) so that it can be locked by consuming modules.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
