### PR TITLE
fix: support latest rabbitmq version

### DIFF
--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -58,7 +58,7 @@ func TestRunFSCloudExample(t *testing.T) {
 			"access_tags":                permanentResources["accessTags"],
 			"existing_kms_instance_guid": permanentResources["hpcs_south"],
 			"kms_key_crn":                permanentResources["hpcs_south_root_key_crn"],
-			"rabbitmq_version":           "3.12", // Always lock this test into the latest supported RabbitMQ version
+			"rabbitmq_version":           "3.13", // Always lock this test into the latest supported RabbitMQ version
 		},
 		CloudInfoService: sharedInfoSvc,
 	})
@@ -87,7 +87,7 @@ func TestRunCompleteUpgradeExample(t *testing.T) {
 		BestRegionYAMLPath: regionSelectionPath,
 		ResourceGroup:      resourceGroup,
 		TerraformVars: map[string]interface{}{
-			"rabbitmq_version": "3.11", // Always lock to the lowest supported RabbitMQ version
+			"rabbitmq_version": "3.12", // Always lock to the lowest supported RabbitMQ version
 			"users": []map[string]interface{}{
 				{
 					"name":     "testuser",

--- a/variables.tf
+++ b/variables.tf
@@ -20,10 +20,10 @@ variable "rabbitmq_version" {
   validation {
     condition = anytrue([
       var.rabbitmq_version == null,
-      var.rabbitmq_version == "3.11",
-      var.rabbitmq_version == "3.12"
+      var.rabbitmq_version == "3.12",
+      var.rabbitmq_version == "3.13"
     ])
-    error_message = "Version must be 3.11 or 3.12. If no value passed, the current ICD preferred version is used."
+    error_message = "Version must be 3.12 or 3.13. If no value passed, the current ICD preferred version is used."
   }
 }
 


### PR DESCRIPTION
### Description

We got the following failure in continuous tests

````hcl
TestPlanICDVersions/3.13 2024-10-24T05:10:42Z retry.go:99: Returning due to fatal error: FatalError{Underlying: error while running command: exit status 1; ╷
│ Error: Invalid value for variable
│ 
│   on [main.tf](http://main.tf/) line 24, in module "icd_rabbitmq":
│   24:   rabbitmq_version  = var.rabbitmq_version
│     ├────────────────
│     │ var.rabbitmq_version is "3.13"
│ 
│ Version must be 3.11 or 3.12. If no value passed, the current ICD preferred
│ version is used.
│ 
│ This was checked by the validation rule at ../../variables.tf:20,3-13.
````

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Support the latest rabbitmq version `3.13`. Remove lowerbound version `3.11`.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
