### PR TITLE
fix: drop 3.12 support, add 4.0 support

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -191,16 +191,12 @@
               "required": true,
               "options": [
                 {
-                  "displayname": "3.9",
-                  "value": "3.9"
-                },
-                {
-                  "displayname": "3.12",
-                  "value": "3.12"
-                },
-                {
                   "displayname": "3.13",
                   "value": "3.13"
+                },
+                {
+                  "displayname": "4.0",
+                  "value": "4.0"
                 }
               ]
             },

--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -2,12 +2,59 @@
 package test
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testhelper"
 )
+
+func TestRunCompleteUpgradeExample(t *testing.T) {
+	t.Parallel()
+
+	// Generate a 15 char long random string for the admin_pass
+	randomBytes := make([]byte, 13)
+	_, err := rand.Read(randomBytes)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// add character prefix to avoid generated password beginning with special char and must have a number
+	randomPass := "A1" + base64.URLEncoding.EncodeToString(randomBytes)[:13]
+
+	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
+		Testing:            t,
+		TerraformDir:       completeExampleTerraformDir,
+		Prefix:             "rabbitmq-upg",
+		BestRegionYAMLPath: regionSelectionPath,
+		ResourceGroup:      resourceGroup,
+		TerraformVars: map[string]interface{}{
+			"rabbitmq_version": earliestVersion, // Always lock to the lowest supported RabbitMQ version
+			"users": []map[string]interface{}{
+				{
+					"name":     "testuser",
+					"password": randomPass, // pragma: allowlist secret
+					"type":     "database",
+				},
+			},
+			"admin_pass": randomPass,
+		},
+		CloudInfoService: sharedInfoSvc,
+	})
+
+	output, err := options.RunTestUpgrade()
+	if !options.UpgradeTestSkipped {
+		assert.Nil(t, err, "This should not have errored")
+		assert.NotNil(t, output, "Expected some output")
+
+		outputs := options.LastTestTerraformOutputs
+		expectedOutputs := []string{"port", "hostname"}
+		_, outputErr := testhelper.ValidateTerraformOutputs(outputs, expectedOutputs...)
+		assert.NoErrorf(t, outputErr, "Some outputs not found or nil")
+	}
+}
 
 func testPlanICDVersions(t *testing.T, version string) {
 	t.Parallel()
@@ -45,7 +92,8 @@ func TestRunRestoredDBExample(t *testing.T) {
 		ResourceGroup: resourceGroup,
 		Region:        fmt.Sprint(permanentResources["rabbitmqRegion"]),
 		TerraformVars: map[string]interface{}{
-			"rabbitmq_db_crn": permanentResources["rabbitmqCrn"],
+			"rabbitmq_db_crn":  permanentResources["rabbitmqCrn"],
+			"rabbitmq_version": permanentResources["rabbitmqVersion"],
 		},
 		CloudInfoService: sharedInfoSvc,
 	})

--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testhelper"
 )
 
-func TestRunCompleteUpgradeExample(t *testing.T) {
+func TestRunCompleteExample(t *testing.T) {
 	t.Parallel()
 
 	// Generate a 15 char long random string for the admin_pass
@@ -44,16 +44,14 @@ func TestRunCompleteUpgradeExample(t *testing.T) {
 		CloudInfoService: sharedInfoSvc,
 	})
 
-	output, err := options.RunTestUpgrade()
-	if !options.UpgradeTestSkipped {
-		assert.Nil(t, err, "This should not have errored")
-		assert.NotNil(t, output, "Expected some output")
+	output, err := options.RunTestConsistency()
+	assert.Nil(t, err, "This should not have errored")
+	assert.NotNil(t, output, "Expected some output")
 
-		outputs := options.LastTestTerraformOutputs
-		expectedOutputs := []string{"port", "hostname"}
-		_, outputErr := testhelper.ValidateTerraformOutputs(outputs, expectedOutputs...)
-		assert.NoErrorf(t, outputErr, "Some outputs not found or nil")
-	}
+	outputs := options.LastTestTerraformOutputs
+	expectedOutputs := []string{"port", "hostname"}
+	_, outputErr := testhelper.ValidateTerraformOutputs(outputs, expectedOutputs...)
+	assert.NoErrorf(t, outputErr, "Some outputs not found or nil")
 }
 
 func testPlanICDVersions(t *testing.T, version string) {

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -25,8 +25,10 @@ import (
 )
 
 const standardSolutionTerraformDir = "solutions/standard"
+const completeExampleTerraformDir = "examples/complete"
 const fscloudExampleTerraformDir = "examples/fscloud"
-const latestVersion = "3.13"
+const earliestVersion = "3.13"
+const latestVersion = "4.0"
 
 // Use existing resource group
 const resourceGroup = "geretain-test-rabbitmq"
@@ -112,7 +114,7 @@ func TestRunStandardSolutionSchematics(t *testing.T) {
 		{Name: "existing_backup_kms_key_crn", Value: permanentResources["hpcs_south_root_key_crn"], DataType: "string"},
 		{Name: "kms_endpoint_type", Value: "private", DataType: "string"},
 		{Name: "resource_group_name", Value: options.Prefix, DataType: "string"},
-		{Name: "rabbitmq_version", Value: "3.13", DataType: "string"}, // Always lock this test into the latest supported RabbitMQ version
+		{Name: "rabbitmq_version", Value: latestVersion, DataType: "string"}, // Always lock this test into the latest supported RabbitMQ version
 		{Name: "service_credential_names", Value: string(serviceCredentialNamesJSON), DataType: "map(string)"},
 		{Name: "existing_secrets_manager_instance_crn", Value: permanentResources["secretsManagerCRN"], DataType: "string"},
 		{Name: "service_credential_secrets", Value: serviceCredentialSecrets, DataType: "list(object)"},
@@ -164,7 +166,7 @@ func TestPlanValidation(t *testing.T) {
 	options.TerraformOptions.Vars = map[string]any{
 		"prefix":              options.Prefix,
 		"region":              "us-south",
-		"rabbitmq_version":    "3.13",
+		"rabbitmq_version":    earliestVersion,
 		"provider_visibility": "public",
 		"resource_group_name": options.Prefix,
 	}

--- a/variables.tf
+++ b/variables.tf
@@ -20,10 +20,10 @@ variable "rabbitmq_version" {
   validation {
     condition = anytrue([
       var.rabbitmq_version == null,
-      var.rabbitmq_version == "3.12",
-      var.rabbitmq_version == "3.13"
+      var.rabbitmq_version == "3.13",
+      var.rabbitmq_version == "4.0",
     ])
-    error_message = "Version must be 3.12 or 3.13. If no value passed, the current ICD preferred version is used."
+    error_message = "Version must be 3.13 or 4.0. If no value passed, the current ICD preferred version is used."
   }
 }
 


### PR DESCRIPTION
### Description

Remove validation for versions of messages for rabbitmq that are no longer supported by the service and adding support for version 4.0 that is in preview.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Remove support for rabbitmq version 3.12, the service has reached end of life.
Add support for rabbitmq version 4.0, the service is available in preview.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
